### PR TITLE
Don't wait for non-js sketches to be loaded, because they will never …

### DIFF
--- a/lib/g.js
+++ b/lib/g.js
@@ -696,7 +696,7 @@
 
       if (! isk())
          return;
-      sketch = sk(); 
+      sketch = sk();
 
       if (sketch.isMakingGlyph) {
          if (! (sketch instanceof Sketch2D))
@@ -835,18 +835,24 @@
 
                   // Ignore files with no extension.
                   var iDot = filename.indexOf('.');
-                  if (iDot < 0)
+                  if (iDot < 0) {
+                     remainingRequests.count--;
                      continue;
+                  }
 
                   // Ignore files that do not have the .js extension.
                   var extension = filename.substring(iDot, filename.length);
-                  if (extension !== '.js')
+                  if (extension !== '.js') {
+                     remainingRequests.count--;
                      continue;
+                  }
 
                   // Ignore the ignoredSketches.
                   var name = filename.substring(0, iDot);
-                  if (getIndex(ignoredSketches, name) >= 0)
+                  if (getIndex(ignoredSketches, name) >= 0) {
+                     remainingRequests.count--;
                      continue;
+                  }
 
                   importSketch(filename, remainingRequests);
                }
@@ -2025,7 +2031,7 @@ console.log(harry.fred);
 
             if (sk().text.length > 0) {
                setTextMode(true);
-               for (var i = 0 ; i < glyphs.length ; i++) 
+               for (var i = 0 ; i < glyphs.length ; i++)
                   if (glyphs[i].name == sk().text) {
                      sk().fade();
                      glyphs[i].toFreehandSketch((sk().xhi + sk().xlo) / 2,


### PR DESCRIPTION
…be loaded. This caused chalktalk to freeze if a swp file was open in vim.
