### PR TITLE
Please Review : Start-up crash fixes 

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,8 +57,7 @@
 
 <!-- THE HTML SLIDE SHOW -->
 
-<script src="content/171020.js">
-<!!script src="content/blank_page.js">
+<script src="content/blank_page.js">
 </script>
 
 <style>

--- a/sketches/blob.js
+++ b/sketches/blob.js
@@ -13,7 +13,7 @@ function() {
          switch (mode) {
 	 case 0:
             t = x * x + y * y + z * z;
-            s = .2 + t + noise.noise([2*x,2*y,2*z + .5 * time]) / 2;
+            s = .2 + t + noise([2*x,2*y,2*z + .5 * time]) / 2;
 	    break;
 
 	 case 1:
@@ -47,7 +47,6 @@ function() {
       return V;
    }
    var n = 60, V, P, T, N;
-   var noise = new Noise();
    this.label = 'blob';
    this.render = function() {
       this.duringSketch(function() {

--- a/sketches/mask.js
+++ b/sketches/mask.js
@@ -140,12 +140,10 @@ function() {
       return [sign * x, y, z];
    }
 
-   var noise = new Noise();
-
    this.flexValues = newArray(3 + flexData.length / 2);
 
    this.computeFlexValue = function(n) {
-      var value = 5 * jtrAmpl[n] * noise.noise([n + .5, .5, jtrFreq[n] * time * 2]) + (n==3 ? -1 : 0);
+      var value = 5 * jtrAmpl[n] * noise([n + .5, .5, jtrFreq[n] * time * 2]) + (n==3 ? -1 : 0);
       var t = this.inValues[n];
       if (t !== undefined) {
          switch (n) {


### PR DESCRIPTION
- in index.html, removed a script tag referring to a non-existent file. (The file was for a presentation.)
     - Note: is there a more automated way we can load slide-show sequences to avoid GET crashes?
- replaced references to the deprecated `Noise` object with calls to `noise()` (the anonymous closure that uses an `ImprovedNoise` object internally and returns a function). **Please verify that this change is correct**. 