### PR TITLE
Installation Page Link Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ and Chalktalk continues to evolve.
 
 ## Installation and Usage
 
-[Installation instructions can be found in the wiki](https://github.com/kenperlin/chalktalk/wiki/Creating-a-Sketch).
+[Installation instructions can be found in the wiki](https://github.com/kenperlin/chalktalk/wiki/Installation-Running).
 
 More complete documentation on the usage of the system can be found there as well, but is a work in progress.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ and Chalktalk continues to evolve.
 
 ## Installation and Usage
 
-[Installation instructions can be found in the wiki](https://github.com/kenperlin/chalktalk/wiki/Installation-Running).
+[Installation instructions can be found in the wiki](https://github.com/kenperlin/chalktalk/wiki/Installation-and-Running).
 
 More complete documentation on the usage of the system can be found there as well, but is a work in progress.
 


### PR DESCRIPTION
I see that the installation link was redirected to the creating-a-sketch page, but shouldn't it lead to the installation-and-running page?