### PR TITLE
Improvements to Help Mode Pie Menu Visuals

### DIFF
--- a/lib/sketchPage.js
+++ b/lib/sketchPage.js
@@ -1950,7 +1950,7 @@
          if (! isShowingGlyphs && ! isTextMode) {
             color(overlayColor);
             lineWidth(1);
-	    let sc = 24, font = floor(sc*12/18) + 'pt Arial';
+	    let sc = 26, font = floor(sc*12/18) + 'pt Arial';
             let y0 = 10 - _g.panY;
             for (let j = 0 ; j < hotKeyMenu.length ; j++) {
                let y = y0 + j * sc*14/18;

--- a/lib/toolTips.js
+++ b/lib/toolTips.js
@@ -270,7 +270,7 @@ window.Tooltips = (function() {
       else {
          isScreenView = true;
 
-         _g.textHeight = 14;
+         _g.textHeight = 15;
 
          x = bgClickCount == 0 ? sketchPage.x : bgClickX;
          y = bgClickCount == 0 ? sketchPage.y : bgClickY;
@@ -284,12 +284,12 @@ window.Tooltips = (function() {
          for (i = -1 ; i < 8 ; i++) {
             var str = '';
             if (bgClickGestures[i] !== undefined)
-               str += '\u2022' + bgClickGestures[i][0];
+               str += ((i == -1) ? '' : '\u2022') + bgClickGestures[i][0];
             if (bgDragGestures[i] !== undefined) {
                if (str.length > 0)
                   str += '\n';
                else if (i == -1)
-                  str += '\n\n';
+                  str += '\n';
                str += '-' + bgDragGestures[i][0];
             }
             if (str.length > 0) {
@@ -304,8 +304,11 @@ window.Tooltips = (function() {
                }
                color(overlayColor);
                var data = bgClickGestures[i];
-               _g.textHeight = 14;
-               utext(str, cx - dx[i], cy + .5 * dy[i], .5, .5);
+               _g.textHeight = 15;
+               if (i == -1) {
+                  dy[i] = r / 3;
+               }
+               utext(str, cx - (1.1 * dx[i]), cy + .6 * dy[i], .5, .5);
             }
          }
          isScreenView = false;

--- a/lib/toolTips.js
+++ b/lib/toolTips.js
@@ -283,8 +283,12 @@ window.Tooltips = (function() {
          var dy = [0,rs,r, rs, 0,-rs,-r,-rs]; dy[-1] = 0;
          for (i = -1 ; i < 8 ; i++) {
             var str = '';
-            if (bgClickGestures[i] !== undefined)
-               str += ((i == -1) ? '' : '\u2022') + bgClickGestures[i][0];
+            if (bgClickGestures[i] !== undefined) {
+               if (i != -1) {
+                  str += '\u2022';
+               }
+               str += bgClickGestures[i][0];
+            }
             if (bgDragGestures[i] !== undefined) {
                if (str.length > 0)
                   str += '\n';
@@ -305,10 +309,8 @@ window.Tooltips = (function() {
                color(overlayColor);
                var data = bgClickGestures[i];
                _g.textHeight = 15;
-               if (i == -1) {
-                  dy[i] = r / 3;
-               }
-               utext(str, cx - (1.1 * dx[i]), cy + .6 * dy[i], .5, .5);
+
+               utext(str, cx - (1.1 * dx[i]), cy + .6 * ((i == -1) ? r / 3 : dy[i]), .5, .5);
             }
          }
          isScreenView = false;

--- a/lib/toolTips.js
+++ b/lib/toolTips.js
@@ -270,7 +270,7 @@ window.Tooltips = (function() {
       else {
          isScreenView = true;
 
-         _g.textHeight = 13;
+         _g.textHeight = 14;
 
          x = bgClickCount == 0 ? sketchPage.x : bgClickX;
          y = bgClickCount == 0 ? sketchPage.y : bgClickY;
@@ -299,12 +299,12 @@ window.Tooltips = (function() {
                   color(overlayColor);
                   fillOval(cx - .18 * r, cy - .18 * r, .36 * r, .36 * r);
                   color(backgroundColor);
-                  _g.textHeight = 14;
+                  _g.textHeight = 16;
                   utext(i == -1 ? '1' : '2', cx, cy-.25, .5, .5);
                }
                color(overlayColor);
                var data = bgClickGestures[i];
-               _g.textHeight = 13;
+               _g.textHeight = 14;
                utext(str, cx - dx[i], cy + .5 * dy[i], .5, .5);
             }
          }


### PR DESCRIPTION
## Changes
- font for left-side keyboard command list and options on pie menu enlarged slightly for better legibility
- pie menu pan option lowered so the center "1" button does not obscure it

#### Compare left (current) and right (revised)
![help_mode_comp](https://user-images.githubusercontent.com/16908296/32471518-b45fa230-c32b-11e7-9bf5-c84f3641acdd.png)
